### PR TITLE
Explicitly link with pthread

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,9 +1,10 @@
-CXXFLAGS=-std=c++11 -Wall -pedantic
+CXXFLAGS=-std=c++11 -Wall -pedantic -pthread
+LDFLAGS = -lpthread
 examples = example1 example2 example3 example4 example5 example6
 all: $(examples)
 
 $(examples): %: %.cpp
-	$(CXX) $(CXXFLAGS) -o $@ $<
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $<
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
For gcc/clang you need to explicitly add -pthread to the compiler and link with the pthread library.

Before:

$ make CXX=clang++
clang++ -std=c++11 -Wall -pedantic -o example1 example1.cpp
/tmp/example1-a78991.o: In function `std::thread::thread<void (&)(px::Scheduler*, unsigned short), px::Scheduler*, unsigned short&>(void (&)(px::Scheduler*, unsigned short), px::Scheduler*&&, unsigned short&)':
example1.cpp:(.text._ZNSt6threadC2IRFvPN2px9SchedulerEtEJS3_RtEEEOT_DpOT0_[_ZNSt6threadC2IRFvPN2px9SchedulerEtEJS3_RtEEEOT_DpOT0_]+0xa6): undefined reference to `pthread_create'
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)
Makefile:6: recipe for target 'example1' failed
make: *** [example1] Error 1

After:
 $ make CXX=clang++
clang++ -std=c++11 -Wall -pedantic -pthread -lpthread -o example1 example1.cpp
clang++ -std=c++11 -Wall -pedantic -pthread -lpthread -o example2 example2.cpp
clang++ -std=c++11 -Wall -pedantic -pthread -lpthread -o example3 example3.cpp
clang++ -std=c++11 -Wall -pedantic -pthread -lpthread -o example4 example4.cpp
clang++ -std=c++11 -Wall -pedantic -pthread -lpthread -o example5 example5.cpp
clang++ -std=c++11 -Wall -pedantic -pthread -lpthread -o example6 example6.cpp



After
