### PR TITLE
Explicitly link with pthread

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,15 +1,15 @@
-CXXFLAGS=-std=c++11 -Wall -pedantic
+CXXFLAGS=-std=c++11 -Wall -pedantic -pthread
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-  CXXCFLAGS += -lpthread
+  LDFLAGS += -lpthread
 endif
 
 examples = example1 example2 example3 example4 example5 example6
 all: $(examples)
 
 $(examples): %: %.cpp ../px_sched.h
-	$(CXX) $(CXXFLAGS) -o $@ $<
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $<
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Need to explicitly link with libpthread on Linux via . On both platform you should pass -pthread (note, NOT -lpthread). Tested on Ubuntu 16.04 and macOS 10.13 